### PR TITLE
Perf update on pathing

### DIFF
--- a/MonsterMashup/MonsterMashup/ModState.cs
+++ b/MonsterMashup/MonsterMashup/ModState.cs
@@ -2,6 +2,7 @@
 using MonsterMashup.Helper;
 using MonsterMashup.UI;
 using System.Collections.Generic;
+using IRBTModUtils.Extension;
 using UnityEngine;
 
 namespace MonsterMashup
@@ -30,6 +31,29 @@ namespace MonsterMashup
         //internal static Dictionary<string, List<SupportSpawnState>> ChildSpawns = new Dictionary<string, List<SupportSpawnState>>();
 
         internal static HashSet<AbstractActor> Parents = new HashSet<AbstractActor>();
+        
+        internal static Dictionary<string, int> ActorDistinctIds = new Dictionary<string, int>();
+        internal static Dictionary<AbstractActor, int> ActorIds = new Dictionary<AbstractActor, int>();
+        internal static int NextActorId = 1;
+
+        internal static int GetActorId(AbstractActor actor)
+        {
+            if(!ActorIds.TryGetValue(actor, out int actorId))
+            {
+                // force to lower to ignore case conditions
+                var actorDistinctId = actor.DistinctId().ToLower();
+                if (!ActorDistinctIds.TryGetValue(actorDistinctId, out actorId))
+                {
+                    actorId = NextActorId++;
+                    ActorDistinctIds.Add(actorDistinctId, actorId);
+                }
+                
+                ActorIds.Add(actor, actorId);
+            }
+            return actorId;
+            
+        }
+        
 
         internal static void Reset()
         {
@@ -53,6 +77,9 @@ namespace MonsterMashup
             WeaponAttachTransforms.Clear();
             //ChildSpawns.Clear();            
             Parents.Clear();
+            
+            ActorDistinctIds.Clear();
+            ActorIds.Clear();
         }
     }
 

--- a/MonsterMashup/MonsterMashup/Patch/PathingPatches.cs
+++ b/MonsterMashup/MonsterMashup/Patch/PathingPatches.cs
@@ -37,7 +37,8 @@ namespace MonsterMashup.Patch
             // Check for any oversized actors, and block if within radius of them. It's crude, but should work?
             foreach (AbstractActor actor in allActors)
             {
-                if (unit.DistinctId().Equals(actor.DistinctId(), System.StringComparison.InvariantCultureIgnoreCase)) continue; // Nothing to do, it's ourselves
+                var unitId = ModState.GetActorId(unit);
+                if (unitId == ModState.GetActorId(actor)) continue; // Nothing to do, it's ourselves
 
                 Mod.Log.Trace?.Write($" -- Checking collision for actor: {unit.DistinctId()}, result: {__result}");
 


### PR DESCRIPTION
MM was checking if 2 actors where the same via a UniqueID check, however string equality is pretty slow.

Instead UniqueIDs are now mapped to an integer ID and actors are then mapped using this to an Actor to Integer ID, allowing for quick dictionary lookups and integer comparison to see if they are the same unit.

This should speed up HasCollisionAt